### PR TITLE
Add common ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+# Python virtual environment directories
 venv/
+.venv/
+
+# Node dependencies
 frontend/node_modules/
+node_modules/
+
+# Python cache and bytecode
 __pycache__/
+*.pyc
+
+# Log files
+*.log
+
+# macOS system files
+.DS_Store


### PR DESCRIPTION
## Summary
- add Python and Node ignore patterns
- keep node_modules and venv entries

## Testing
- `npm run lint` *(fails: cannot find package)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c4bad01508333bc5e506a55ce20c0