### PR TITLE
Handle missing secret key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
+# 例: django-insecure-examplekey1234567890abcdef
 DJANGO_SECRET_KEY=

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -21,7 +21,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "unsafe-default-key")
+# 環境変数が未設定の場合は例外を送出
+SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("DJANGO_SECRET_KEY environment variable is not set.")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## Summary
- raise `RuntimeError` if `DJANGO_SECRET_KEY` is missing
- add example key comment in `.env.example`

## Testing
- `python backend/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_684c503614688333983bdc780dd1c302