### PR TITLE
Add Cloud Run deployment setup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV PORT=8080
+CMD ["gunicorn", "backend.wsgi:application", "-b", "0.0.0.0:8080"]

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -29,7 +29,13 @@ if not SECRET_KEY:
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["hukulink.awana.co.jp", "localhost"]
+
+CORS_ALLOWED_ORIGINS = [
+    "https://hukulink.awana.co.jp",
+]
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 
 # Application definition

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 Django>=5.2
 psycopg[binary]
+gunicorn

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,30 @@
+steps:
+# ---------- FRONTEND ----------
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build','-t','gcr.io/$PROJECT_ID/hukulink-frontend:$COMMIT_SHA','frontend']
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: [
+    'run','deploy','hukulink-frontend',
+    '--image','gcr.io/$PROJECT_ID/hukulink-frontend:$COMMIT_SHA',
+    '--region','asia-northeast1',
+    '--platform','managed',
+    '--allow-unauthenticated',
+    '--port','8080'
+  ]
+
+# ---------- BACKEND ----------
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build','-t','gcr.io/$PROJECT_ID/hukulink-backend:$COMMIT_SHA','backend']
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: [
+    'run','deploy','hukulink-backend',
+    '--image','gcr.io/$PROJECT_ID/hukulink-backend:$COMMIT_SHA',
+    '--region','asia-northeast1',
+    '--platform','managed',
+    '--allow-unauthenticated',
+    '--port','8080',
+    '--set-env-vars','DATABASE_URL=${_DATABASE_URL},DJANGO_SECRET_KEY=${_DJANGO_SECRET_KEY}'
+  ]
+images:
+- 'gcr.io/$PROJECT_ID/hukulink-frontend:$COMMIT_SHA'
+- 'gcr.io/$PROJECT_ID/hukulink-backend:$COMMIT_SHA'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+# ---------- build ----------
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# ---------- runtime ----------
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+RUN printf "server {\n  listen 8080;\n  root /usr/share/nginx/html;\n  location /api/ { return 404; }\n  try_files \$uri /index.html;\n}" > /etc/nginx/conf.d/default.conf
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/',
 })


### PR DESCRIPTION
## Summary
- setup base URL for Vite build
- add Dockerfile for Django backend and React frontend
- install gunicorn for backend runtime
- add Cloud Build configuration
- update Django settings for production use

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `python backend/manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_684d52ad90948333adb3a15933279ecb